### PR TITLE
feat(docker): Use alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-alpine
 
 ARG CLI_DIR=/opt/cli/
 ARG USER_GROUP_ID=nexus3casc
@@ -6,7 +6,7 @@ ARG USER_GROUP_ID=nexus3casc
 RUN pip install pipenv
 
 RUN mkdir -p ${CLI_DIR} && \
-    useradd -m -s /bin/bash -U ${USER_GROUP_ID} && \
+    adduser -s /bin/sh -D ${USER_GROUP_ID} && \
     chown ${USER_GROUP_ID}:${USER_GROUP_ID} ${CLI_DIR}
 
 WORKDIR ${CLI_DIR}
@@ -18,6 +18,6 @@ COPY nexuscasc ${CLI_DIR}/nexuscasc
 COPY Pipfile* ${CLI_DIR}
 COPY resources ${CLI_DIR}/resources
 
-RUN pipenv install --system --deploy --ignore-pipfile
+RUN pipenv install --deploy --ignore-pipfile
 
-ENTRYPOINT ["python", "/opt/cli/nexus3casc.py"]
+ENTRYPOINT ["pipenv", "run", "nexus3casc"]


### PR DESCRIPTION
Now it uses alpine as parent image instead of debian-slim.

Security analysis reported by Quay.io detects some vulnerabilities in
the docker image python:3-8-debian-slim. However using python:3-8-alpine
no issues were reported.
